### PR TITLE
Evaluate only current node on Sequence and Selector

### DIFF
--- a/src/Nodes/SelectorNode.cs
+++ b/src/Nodes/SelectorNode.cs
@@ -36,7 +36,9 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            while (this.enumerator.MoveNext())
+            if (this.enumerator.Current == null)
+                this.enumerator.MoveNext();
+            while (this.enumerator.Current != null)
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Failure)
@@ -45,6 +47,9 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
+
+                if (!this.enumerator.MoveNext())
+                    break;
             }
             this.enumerator.Reset();
             return BehaviourTreeStatus.Failure;

--- a/src/Nodes/SelectorNode.cs
+++ b/src/Nodes/SelectorNode.cs
@@ -36,7 +36,7 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            do
+            while (this.enumerator.MoveNext())
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Failure)
@@ -45,7 +45,7 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
-            } while (this.enumerator.MoveNext());
+            }
             this.enumerator.Reset();
             return BehaviourTreeStatus.Failure;
         }

--- a/src/Nodes/SelectorNode.cs
+++ b/src/Nodes/SelectorNode.cs
@@ -25,17 +25,28 @@ namespace FluentBehaviourTree
             this.name = name;
         }
 
+        private IEnumerator<IBehaviourTreeNode> enumerator;
+
+        public void Init()
+        {
+            this.enumerator = this.children.GetEnumerator();
+        }
+
         public BehaviourTreeStatus Tick(TimeData time)
         {
-            foreach (var child in children)
+            if (this.enumerator == null)
+                this.Init();
+            do
             {
-                var childStatus = child.Tick(time);
+                var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Failure)
                 {
+                    if (childStatus == BehaviourTreeStatus.Success)
+                        this.enumerator.Reset();
                     return childStatus;
                 }
-            }
-
+            } while (this.enumerator.MoveNext());
+            this.enumerator.Reset();
             return BehaviourTreeStatus.Failure;
         }
 

--- a/src/Nodes/SequenceNode.cs
+++ b/src/Nodes/SequenceNode.cs
@@ -36,7 +36,7 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            do
+            while (this.enumerator.MoveNext())
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Success)
@@ -45,7 +45,7 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
-            } while (this.enumerator.MoveNext());
+            } 
             this.enumerator.Reset();
             return BehaviourTreeStatus.Success;
         }

--- a/src/Nodes/SequenceNode.cs
+++ b/src/Nodes/SequenceNode.cs
@@ -25,17 +25,28 @@ namespace FluentBehaviourTree
             this.name = name;
         }
 
+        private IEnumerator<IBehaviourTreeNode> enumerator;
+
+        public void Init()
+        {
+            this.enumerator = this.children.GetEnumerator();
+        }
+
         public BehaviourTreeStatus Tick(TimeData time)
         {
-            foreach (var child in children)
+            if (this.enumerator == null)
+                this.Init();
+            do
             {
-                var childStatus = child.Tick(time);
+                var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Success)
                 {
+                    if (childStatus == BehaviourTreeStatus.Failure)
+                        this.enumerator.Reset();
                     return childStatus;
                 }
-            }
-
+            } while (this.enumerator.MoveNext());
+            this.enumerator.Reset();
             return BehaviourTreeStatus.Success;
         }
 

--- a/src/Nodes/SequenceNode.cs
+++ b/src/Nodes/SequenceNode.cs
@@ -36,7 +36,9 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            while (this.enumerator.MoveNext())
+            if (this.enumerator.Current == null)
+                this.enumerator.MoveNext();
+            while (this.enumerator.Current != null)
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Success)
@@ -45,6 +47,8 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
+                if (!this.enumerator.MoveNext())
+                    break;
             } 
             this.enumerator.Reset();
             return BehaviourTreeStatus.Success;


### PR DESCRIPTION
Hi! I have implemented some changes to the Sequence and Selector node to only evaluate the current node on each Tick. This allows to have atomic, non-dependent node actions. nor having to store some sort of status for conditional tests. (it mimics the behavior of the Behave unity asset).