### PR TITLE
Evaluate only current node on Sequence and Selector

### DIFF
--- a/src/Nodes/SelectorNode.cs
+++ b/src/Nodes/SelectorNode.cs
@@ -36,7 +36,9 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            while (this.enumerator.MoveNext())
+            if (this.enumerator.Current == null)
+                this.enumerator.MoveNext();
+            while (this.enumerator.Current != null)
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Failure)
@@ -45,6 +47,9 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
+
+                if (!this.enumerator.MoveNext())
+                    break;
             }
             this.enumerator.Reset();
             return BehaviourTreeStatus.Failure;

--- a/src/Nodes/SelectorNode.cs
+++ b/src/Nodes/SelectorNode.cs
@@ -36,7 +36,7 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            do
+            while (this.enumerator.MoveNext())
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Failure)
@@ -45,7 +45,7 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
-            } while (this.enumerator.MoveNext());
+            }
             this.enumerator.Reset();
             return BehaviourTreeStatus.Failure;
         }

--- a/src/Nodes/SelectorNode.cs
+++ b/src/Nodes/SelectorNode.cs
@@ -25,17 +25,28 @@ namespace FluentBehaviourTree
             this.name = name;
         }
 
+        private IEnumerator<IBehaviourTreeNode> enumerator;
+
+        public void Init()
+        {
+            this.enumerator = this.children.GetEnumerator();
+        }
+
         public BehaviourTreeStatus Tick(TimeData time)
         {
-            foreach (var child in children)
+            if (this.enumerator == null)
+                this.Init();
+            do
             {
-                var childStatus = child.Tick(time);
+                var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Failure)
                 {
+                    if (childStatus == BehaviourTreeStatus.Success)
+                        this.enumerator.Reset();
                     return childStatus;
                 }
-            }
-
+            } while (this.enumerator.MoveNext());
+            this.enumerator.Reset();
             return BehaviourTreeStatus.Failure;
         }
 

--- a/src/Nodes/SequenceNode.cs
+++ b/src/Nodes/SequenceNode.cs
@@ -36,7 +36,7 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            do
+            while (this.enumerator.MoveNext())
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Success)
@@ -45,7 +45,7 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
-            } while (this.enumerator.MoveNext());
+            } 
             this.enumerator.Reset();
             return BehaviourTreeStatus.Success;
         }

--- a/src/Nodes/SequenceNode.cs
+++ b/src/Nodes/SequenceNode.cs
@@ -25,17 +25,28 @@ namespace FluentBehaviourTree
             this.name = name;
         }
 
+        private IEnumerator<IBehaviourTreeNode> enumerator;
+
+        public void Init()
+        {
+            this.enumerator = this.children.GetEnumerator();
+        }
+
         public BehaviourTreeStatus Tick(TimeData time)
         {
-            foreach (var child in children)
+            if (this.enumerator == null)
+                this.Init();
+            do
             {
-                var childStatus = child.Tick(time);
+                var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Success)
                 {
+                    if (childStatus == BehaviourTreeStatus.Failure)
+                        this.enumerator.Reset();
                     return childStatus;
                 }
-            }
-
+            } while (this.enumerator.MoveNext());
+            this.enumerator.Reset();
             return BehaviourTreeStatus.Success;
         }
 

--- a/src/Nodes/SequenceNode.cs
+++ b/src/Nodes/SequenceNode.cs
@@ -36,7 +36,9 @@ namespace FluentBehaviourTree
         {
             if (this.enumerator == null)
                 this.Init();
-            while (this.enumerator.MoveNext())
+            if (this.enumerator.Current == null)
+                this.enumerator.MoveNext();
+            while (this.enumerator.Current != null)
             {
                 var childStatus = this.enumerator.Current.Tick(time);
                 if (childStatus != BehaviourTreeStatus.Success)
@@ -45,6 +47,8 @@ namespace FluentBehaviourTree
                         this.enumerator.Reset();
                     return childStatus;
                 }
+                if (!this.enumerator.MoveNext())
+                    break;
             } 
             this.enumerator.Reset();
             return BehaviourTreeStatus.Success;

--- a/tests/SelectorNodeTests.cs
+++ b/tests/SelectorNodeTests.cs
@@ -115,6 +115,39 @@ namespace tests
             mockChild2.Verify(m => m.Tick(time), Times.Once());
         }
 
+
+        [Fact]
+        public void selector_only_evaluates_the_current_node()
+        {
+            Init();
+
+            var time = new TimeData();
+
+            var mockChild1 = new Mock<IBehaviourTreeNode>();
+            mockChild1
+                .Setup(m => m.Tick(time))
+                .Returns(BehaviourTreeStatus.Failure);
+
+            var mockChild2 = new Mock<IBehaviourTreeNode>();
+            mockChild2
+                .Setup(m => m.Tick(time))
+                .Returns(BehaviourTreeStatus.Running);
+            var mockChild3 = new Mock<IBehaviourTreeNode>();
+            mockChild3
+                .Setup(m => m.Tick(time))
+                .Returns(BehaviourTreeStatus.Success);
+
+            testObject.AddChild(mockChild1.Object);
+            testObject.AddChild(mockChild2.Object);
+            testObject.AddChild(mockChild3.Object);
+
+            Assert.Equal(BehaviourTreeStatus.Running, testObject.Tick(time));
+            Assert.Equal(BehaviourTreeStatus.Running, testObject.Tick(time));
+
+            mockChild1.Verify(m => m.Tick(time), Times.Once());
+            mockChild2.Verify(m => m.Tick(time), Times.Exactly(2));
+            mockChild3.Verify(m => m.Tick(time), Times.Never());
+        }
     }
 }
 

--- a/tests/SequenceNodeTests.cs
+++ b/tests/SequenceNodeTests.cs
@@ -126,5 +126,38 @@ namespace tests
             mockChild1.Verify(m => m.Tick(time), Times.Once());
             mockChild2.Verify(m => m.Tick(time), Times.Once());
         }
+
+        [Fact]
+        public void sequence_only_evaluates_the_current_node()
+        {
+            Init();
+
+            var time = new TimeData();
+
+            var mockChild1 = new Mock<IBehaviourTreeNode>();
+            mockChild1
+                .Setup(m => m.Tick(time))
+                .Returns(BehaviourTreeStatus.Success);
+
+            var mockChild2 = new Mock<IBehaviourTreeNode>();
+            mockChild2
+                .Setup(m => m.Tick(time))
+                .Returns(BehaviourTreeStatus.Running);
+            var mockChild3 = new Mock<IBehaviourTreeNode>();
+            mockChild3
+                .Setup(m => m.Tick(time))
+                .Returns(BehaviourTreeStatus.Failure);
+
+            testObject.AddChild(mockChild1.Object);
+            testObject.AddChild(mockChild2.Object);
+            testObject.AddChild(mockChild3.Object);
+
+            Assert.Equal(BehaviourTreeStatus.Running, testObject.Tick(time));
+            Assert.Equal(BehaviourTreeStatus.Running, testObject.Tick(time));
+
+            mockChild1.Verify(m => m.Tick(time), Times.Once());
+            mockChild2.Verify(m => m.Tick(time), Times.Exactly(2));
+            mockChild3.Verify(m => m.Tick(time), Times.Never());
+        }
     }
 }


### PR DESCRIPTION
Hi! I have implemented some changes to the Sequence and Selector node to only evaluate the current node on each Tick. This allows to have atomic, non-dependent node actions. nor having to store some sort of status for conditional tests. (it mimics the behavior of the Behave unity asset).
With Unit Tests.